### PR TITLE
Use `require login` in example interview

### DIFF
--- a/docassemble/LegalServerLink/data/questions/sample_letter.yml
+++ b/docassemble/LegalServerLink/data/questions/sample_letter.yml
@@ -9,6 +9,7 @@ metadata:
   authors:
     - organization: LegalServer
   revision_date: 2023-10-11
+  require login: True
 ---
 features:
   use catchall: True
@@ -25,18 +26,6 @@ include:
 ---
 objects:
   - client_message: DAObject
----
-initial: True
-code: |
-  if not user_logged_in():
-    kick_out_user
----
-event: kick_out_user
-question: |
-  I am sorry, but you need to log in if you want to use this interview.
-buttons:
-  - Log in: signin
-  - Exit: exit
 ---
 mandatory: True
 code: |


### PR DESCRIPTION
This is a matter of taste, but for non-external interviews I think it is good to use `require login: True` because users will be redirected to the login page and, on servers like PLA's, will be transparently logged in because of `auto login`.